### PR TITLE
fix: can not read `data` of undefined

### DIFF
--- a/change/@farbenmeer-deadbolt-fc531b59-e9bd-4906-8818-2b57b5263fe8.json
+++ b/change/@farbenmeer-deadbolt-fc531b59-e9bd-4906-8818-2b57b5263fe8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: can not read `data` of undefined",
+  "packageName": "@farbenmeer/deadbolt",
+  "email": "tobi.l@posteo.at",
+  "dependentChangeType": "patch"
+}

--- a/packages/deadbolt/src/oauth2.ts
+++ b/packages/deadbolt/src/oauth2.ts
@@ -120,7 +120,7 @@ export function oauth2<Data>({ plugins = [], providers, config: initialConfig }:
     await refreshIfNecessary(context);
     if (!context.provider) return undefined;
     await hooks.retrieveData(context);
-    if (!context.connected[context.provider.name].data) await context.provider.loadData?.(context);
+    if (!context.connected[context.provider.name]?.data) await context.provider.loadData?.(context);
     return context.connected[providerName];
   }
 


### PR DESCRIPTION
This resolves an error in the `getData` function when the value of connected `context.provider.name` is empty. This happens if the given provider name is not valid e.g. has a typo or something.  We can also think about throwing an error here with the message that the provider name was not initialized and has now the value undefined.